### PR TITLE
fixing the error on `https://github.com/Arian-D/incuscore/actions/workflows/build-iso.yml`

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -29,8 +29,8 @@ on:
 env:
   # Define the exact image to pull
   # This image is expected to be built and pushed by a separate workflow (e.g., build.yml in Arian-D/incuscore)
-  PREBUILT_IMAGE_PATH: "ghcr.io/arian-d/incuscore"
-  PREBUILT_IMAGE_TAG: "latest" # Or a specific tag like "20250507" for reproducibility
+  PREBUILT_IMAGE_PATH: "ghcr.io/ib-bsb-br/incuscore"
+  PREBUILT_IMAGE_TAG: "latest" # Or a specific tag like "20250507" for reproducibility  
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -46,7 +46,7 @@ jobs:
       - name: lower case the image registry in case of any capitalization
         run: |
           echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> ${GITHUB_ENV}
-      
+
       - name: Install dependencies
         if: inputs.platform == 'arm64'
         run: |
@@ -57,30 +57,24 @@ jobs:
 
       - name: Maximize build space
         if: inputs.platform != 'arm64'
-        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
+        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e
         with:
           remove-codeql: true
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v4
 
-      - name: Log in to GHCR (docker on amd64, podman on arm64)
-        run: |
-          if [ "${{ inputs.platform }}" = "arm64" ]; then
-            echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
-          else
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-          fi
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Setup Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      - name: Pull the Docker image
+        run: docker pull ghcr.io/ib-bsb-br/incuscore:latest
 
       - name: Setup Just
         uses: extractions/setup-just@v3
 
       - name: Ensure yum supports 'check'
         run: |
-          # In CentOS 8+ environments, make yum an alias to dnf so 'check' works.
           sudo ln -sf /usr/bin/dnf /usr/bin/yum
 
       - name: Build ISO
@@ -94,7 +88,7 @@ jobs:
 
       - name: Upload ISOs and Checksum to Job Artifacts
         if: inputs.upload-to-s3 != true && github.event_name != 'pull_request'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ steps.build.outputs.output-directory }}
           if-no-files-found: error

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -67,8 +67,13 @@ jobs:
       - name: Log in to GitHub Container Registry
         run: echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Pull the Docker image
-        run: docker pull ghcr.io/ib-bsb-br/incuscore:latest
+      - name: Pull or Build Docker image
+        run: |
+          if ! docker pull ghcr.io/ib-bsb-br/incuscore:latest; then
+            echo "Image not found. Building the image locally..."
+            docker build -t ghcr.io/ib-bsb-br/incuscore:latest .
+            docker push ghcr.io/ib-bsb-br/incuscore:latest
+          fi
 
       - name: Setup Just
         uses: extractions/setup-just@v3

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -64,6 +64,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
+      - name: Log in to GHCR (docker on amd64, podman on arm64)
+        run: |
+          if [ "${{ inputs.platform }}" = "arm64" ]; then
+            echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+          else
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          fi
+
       - name: Setup Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
 
@@ -92,5 +100,4 @@ jobs:
           if-no-files-found: error
           retention-days: 0
           compression-level: 0
-          overwrite: true 
-      
+          overwrite: true

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -22,13 +22,15 @@ on:
       - './iso.toml'
       - './.github/workflows/build-iso.yml'
       - './Justfile'
-      - './Containerfile' # Important: Trigger workflow if Containerfile changes
+      # Containerfile changes in this repo no longer directly trigger ISO rebuilds
+      # unless this workflow is also responsible for testing local Containerfile changes
+      # by building a temporary image. Given the new constraint, we assume it's not.
 
 env:
-  # Consistent image naming, matching build.yml's likely output
-  IMAGE_REGISTRY_OWNER: "ghcr.io/${{ github.repository_owner }}"
-  IMAGE_NAME: "${{ github.event.repository.name }}" # This will be 'incuscore'
-  DEFAULT_TAG: "latest"
+  # Define the exact image to pull
+  # This image is expected to be built and pushed by a separate workflow (e.g., build.yml in Arian-D/incuscore)
+  PREBUILT_IMAGE_PATH: "ghcr.io/arian-d/incuscore"
+  PREBUILT_IMAGE_TAG: "latest" # Or a specific tag like "20250507" for reproducibility
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -42,18 +44,16 @@ jobs:
       fail-fast: false
     permissions:
       contents: read
-      packages: write # Necessary if this workflow pushes the container image
-      id-token: write
+      packages: read # <<< CHANGED to read: only needs to pull the public image
+      id-token: write # Retained if any future steps might need OIDC
 
     steps:
-      - name: Prepare image path variables
+      - name: Prepare full image path variable
         id: prep_vars
         run: |
-          REG_OWNER_LOWER=$(echo "${{ env.IMAGE_REGISTRY_OWNER }}" | tr '[:upper:]' '[:lower:]')
-          IMG_NAME_LOWER=$(echo "${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
-          echo "FULL_IMAGE_PATH=${REG_OWNER_LOWER}/${IMG_NAME_LOWER}:${DEFAULT_TAG}" >> $GITHUB_ENV
-          echo "IMAGE_REGISTRY_PATH=${REG_OWNER_LOWER}/${IMG_NAME_LOWER}" >> $GITHUB_ENV
-
+          FULL_IMAGE_TO_PULL="${{ env.PREBUILT_IMAGE_PATH }}:${{ env.PREBUILT_IMAGE_TAG }}"
+          echo "FULL_IMAGE_TO_PULL=${FULL_IMAGE_TO_PULL}" >> $GITHUB_ENV
+          echo "Image to be used for ISO: ${FULL_IMAGE_TO_PULL}"
 
       - name: Install dependencies (for arm64 runner)
         if: inputs.platform == 'arm64'
@@ -68,36 +68,25 @@ jobs:
         with:
           remove-codeql: true
 
-      - name: Checkout repository
+      - name: Checkout repository (contains iso.toml, Justfile etc.)
         uses: actions/checkout@v4
 
-      - name: Log in to GitHub Container Registry
-        # Use GITHUB_TOKEN for GHCR authentication.
-        # The GITHUB_TOKEN has necessary permissions when 'packages: write' is set.
+      - name: Log in to GitHub Container Registry (to pull image)
+        # While ghcr.io/arian-d/incuscore is public, login can prevent rate limits
+        # and is good practice if any private base images were ever involved.
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Pull or Build Container image
+      - name: Pull Pre-built Container Image
         run: |
-          echo "Attempting to pull image: ${{ env.FULL_IMAGE_PATH }}"
-          if ! docker pull ${{ env.FULL_IMAGE_PATH }}; then
-            echo "Image not found or pull failed. Building the image locally from Containerfile..."
-            # CRITICAL FIX: Use -f Containerfile to specify the correct build file
-            docker build -f Containerfile -t ${{ env.FULL_IMAGE_PATH }} .
-            
-            echo "Pushing the locally built image to ${{ env.FULL_IMAGE_PATH }}..."
-            # This push makes this workflow also a publisher of the container image.
-            # Ensure this is intended, or rely solely on your 'build.yml' workflow to publish.
-            docker push ${{ env.FULL_IMAGE_PATH }}
-          else
-            echo "Successfully pulled image ${{ env.FULL_IMAGE_PATH }}"
-          fi
+          echo "Attempting to pull ${{ env.FULL_IMAGE_TO_PULL }}"
+          # Workflow will fail here if the image doesn't exist or pull fails.
+          docker pull ${{ env.FULL_IMAGE_TO_PULL }}
+          echo "Successfully pulled image ${{ env.FULL_IMAGE_TO_PULL }}"
 
       - name: Setup Just
         uses: extractions/setup-just@v3
 
       - name: Ensure yum symlink (for tools on runner if needed)
-        # This step is for tools run directly on the Ubuntu runner that might expect 'yum'.
-        # It does not affect the container build process which uses dnf5 from Fedora CoreOS.
         run: |
           if command -v dnf &> /dev/null && ! command -v yum &> /dev/null; then
             sudo ln -sf /usr/bin/dnf /usr/bin/yum
@@ -110,22 +99,19 @@ jobs:
         id: build_iso
         uses: ublue-os/bootc-image-builder-action@main
         with:
-          # Consider aligning with Justfile: quay.io/centos-bootc/bootc-image-builder:latest
-          bootc-image-builder-image: ghcr.io/centos-workstation/bootc-image-builder:latest 
+          bootc-image-builder-image: ghcr.io/centos-workstation/bootc-image-builder:latest
           use-librepo: true
           config-file: ./iso.toml
-          # The 'image' parameter is the source OCI/Docker image to convert into a bootable ISO
-          image: ${{ env.FULL_IMAGE_PATH }}
+          # The 'image' parameter is the source OCI/Docker image to convert
+          image: ${{ env.FULL_IMAGE_TO_PULL }}
 
       - name: Upload ISO and Checksum to Job Artifacts
-        # This step runs only on workflow_dispatch if 'upload-to-s3' is not true,
-        # and not on pull_request events.
         if: inputs.upload-to-s3 != true && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: bootable-iso-${{ inputs.platform || 'amd64' }}
-          path: ${{ steps.build_iso.outputs.output-directory }} # Corrected step ID
+          path: ${{ steps.build_iso.outputs.output-directory }}
           if-no-files-found: error
-          retention-days: 7 # Changed to 7 days, 0 means it's kept indefinitely until manually deleted or repo limit
+          retention-days: 7
           compression-level: 0
           overwrite: true

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -67,6 +67,14 @@ jobs:
       - name: Setup Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
 
+      - name: Setup Just
+        uses: extractions/setup-just@v3
+
+      - name: Ensure yum supports 'check'
+        run: |
+          # In CentOS 8+ environments, make yum an alias to dnf so 'check' works.
+          sudo ln -sf /usr/bin/dnf /usr/bin/yum
+
       - name: Build ISO
         id: build
         uses: ublue-os/bootc-image-builder-action@main
@@ -84,20 +92,5 @@ jobs:
           if-no-files-found: error
           retention-days: 0
           compression-level: 0
-          overwrite: true
+          overwrite: true 
       
-      - name: Upload to S3
-        if: inputs.upload-to-s3 == true && github.event_name != 'pull_request'
-        shell: bash
-        env:
-          RCLONE_CONFIG_S3_TYPE: s3
-          RCLONE_CONFIG_S3_PROVIDER: ${{ secrets.S3_PROVIDER }}
-          RCLONE_CONFIG_S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
-          RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
-          RCLONE_CONFIG_S3_REGION: ${{ secrets.S3_REGION }}
-          RCLONE_CONFIG_S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
-          SOURCE_DIR: ${{ steps.build.outputs.output-directory }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y rclone
-          rclone copy $SOURCE_DIR S3:${{ secrets.S3_BUCKET_NAME }}

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -22,9 +22,12 @@ on:
       - './iso.toml'
       - './.github/workflows/build-iso.yml'
       - './Justfile'
+      - './Containerfile' # Important: Trigger workflow if Containerfile changes
 
 env:
-  IMAGE_REGISTRY: "ghcr.io/${{ github.repository }}"
+  # Consistent image naming, matching build.yml's likely output
+  IMAGE_REGISTRY_OWNER: "ghcr.io/${{ github.repository_owner }}"
+  IMAGE_NAME: "${{ github.event.repository.name }}" # This will be 'incuscore'
   DEFAULT_TAG: "latest"
 
 concurrency:
@@ -39,64 +42,90 @@ jobs:
       fail-fast: false
     permissions:
       contents: read
-      packages: read
+      packages: write # Necessary if this workflow pushes the container image
       id-token: write
 
     steps:
-      - name: lower case the image registry in case of any capitalization
+      - name: Prepare image path variables
+        id: prep_vars
         run: |
-          echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> ${GITHUB_ENV}
+          REG_OWNER_LOWER=$(echo "${{ env.IMAGE_REGISTRY_OWNER }}" | tr '[:upper:]' '[:lower:]')
+          IMG_NAME_LOWER=$(echo "${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
+          echo "FULL_IMAGE_PATH=${REG_OWNER_LOWER}/${IMG_NAME_LOWER}:${DEFAULT_TAG}" >> $GITHUB_ENV
+          echo "IMAGE_REGISTRY_PATH=${REG_OWNER_LOWER}/${IMG_NAME_LOWER}" >> $GITHUB_ENV
 
-      - name: Install dependencies
+
+      - name: Install dependencies (for arm64 runner)
         if: inputs.platform == 'arm64'
         run: |
           set -x
           sudo apt update -y
-          sudo apt install -y \
-            podman
+          sudo apt install -y podman
 
-      - name: Maximize build space
+      - name: Maximize build space (for amd64 runner)
         if: inputs.platform != 'arm64'
         uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e
         with:
           remove-codeql: true
 
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        # Use GITHUB_TOKEN for GHCR authentication.
+        # The GITHUB_TOKEN has necessary permissions when 'packages: write' is set.
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Pull or Build Docker image
+      - name: Pull or Build Container image
         run: |
-          if ! docker pull ghcr.io/ib-bsb-br/incuscore:latest; then
-            echo "Image not found. Building the image locally..."
-            docker build -t ghcr.io/ib-bsb-br/incuscore:latest .
-            docker push ghcr.io/ib-bsb-br/incuscore:latest
+          echo "Attempting to pull image: ${{ env.FULL_IMAGE_PATH }}"
+          if ! docker pull ${{ env.FULL_IMAGE_PATH }}; then
+            echo "Image not found or pull failed. Building the image locally from Containerfile..."
+            # CRITICAL FIX: Use -f Containerfile to specify the correct build file
+            docker build -f Containerfile -t ${{ env.FULL_IMAGE_PATH }} .
+            
+            echo "Pushing the locally built image to ${{ env.FULL_IMAGE_PATH }}..."
+            # This push makes this workflow also a publisher of the container image.
+            # Ensure this is intended, or rely solely on your 'build.yml' workflow to publish.
+            docker push ${{ env.FULL_IMAGE_PATH }}
+          else
+            echo "Successfully pulled image ${{ env.FULL_IMAGE_PATH }}"
           fi
 
       - name: Setup Just
         uses: extractions/setup-just@v3
 
-      - name: Ensure yum supports 'check'
+      - name: Ensure yum symlink (for tools on runner if needed)
+        # This step is for tools run directly on the Ubuntu runner that might expect 'yum'.
+        # It does not affect the container build process which uses dnf5 from Fedora CoreOS.
         run: |
-          sudo ln -sf /usr/bin/dnf /usr/bin/yum
+          if command -v dnf &> /dev/null && ! command -v yum &> /dev/null; then
+            sudo ln -sf /usr/bin/dnf /usr/bin/yum
+            echo "Symlinked /usr/bin/dnf to /usr/bin/yum"
+          else
+            echo "yum command already exists or dnf not found. Skipping symlink."
+          fi
 
-      - name: Build ISO
-        id: build
+      - name: Build ISO using bootc-image-builder
+        id: build_iso
         uses: ublue-os/bootc-image-builder-action@main
         with:
-          bootc-image-builder-image: ghcr.io/centos-workstation/bootc-image-builder:latest
+          # Consider aligning with Justfile: quay.io/centos-bootc/bootc-image-builder:latest
+          bootc-image-builder-image: ghcr.io/centos-workstation/bootc-image-builder:latest 
           use-librepo: true
           config-file: ./iso.toml
-          image: ${{ env.IMAGE_REGISTRY }}:${{ env.DEFAULT_TAG }}
+          # The 'image' parameter is the source OCI/Docker image to convert into a bootable ISO
+          image: ${{ env.FULL_IMAGE_PATH }}
 
-      - name: Upload ISOs and Checksum to Job Artifacts
+      - name: Upload ISO and Checksum to Job Artifacts
+        # This step runs only on workflow_dispatch if 'upload-to-s3' is not true,
+        # and not on pull_request events.
         if: inputs.upload-to-s3 != true && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ steps.build.outputs.output-directory }}
+          name: bootable-iso-${{ inputs.platform || 'amd64' }}
+          path: ${{ steps.build_iso.outputs.output-directory }} # Corrected step ID
           if-no-files-found: error
-          retention-days: 0
+          retention-days: 7 # Changed to 7 days, 0 means it's kept indefinitely until manually deleted or repo limit
           compression-level: 0
           overwrite: true

--- a/build_files/99-user-setup.ign
+++ b/build_files/99-user-setup.ign
@@ -1,0 +1,42 @@
+{
+  "ignition": {
+    "version": "3.4.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "groups": [
+          "wheel"
+        ],
+        "name": "root",
+        "passwordHash": "$6$ImarjE8isRQ3fdG4$XBBMTFIq3TjyhSBIJodNWuRiqPjn1nKs9L7LW4qC0M0cbu5EOn63Pl4xQCMr04Y/6Ib88rYtDERgaJueri4Ej0",
+        "sshAuthorizedKeys": [
+          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBw0ESzeBbzVmMBfj+bqtsnccZd1u7oxFiIHk3f/YKva root@linaro-alip"
+        ]
+      },
+      {
+        "groups": [
+          "wheel"
+        ],
+        "name": "core",
+        "passwordHash": "$6$a1F99ldZOvodWKiN$mrZ13gTH.q7LAio3B.9oEUKBYbxIt82uOKKh5qsgMo04414KLOAPZinxXKlwrrYWScZJk8Ut367CVtdvtaJpg.",
+        "sshAuthorizedKeys": [
+          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKuoxCeNmDET5XjZaQPr5ANdhSmOWbI1iSVABWhRPeFl linaro@linaro-alip"
+        ]
+      }
+    ]
+  },
+  "systemd": {
+    "units": [
+      {
+        "dropins": [
+          {
+            "contents": "[Service]\nExecStart=\nExecStart=-/sbin/agetty --autologin root --noclear %I $TERM\n",
+            "name": "10-autologin.conf"
+          }
+        ],
+        "name": "getty@tty1.service"
+      }
+    ]
+  }
+}

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -2,6 +2,21 @@
 
 set -ouex pipefail
 
+echo "Embedding custom Ignition configuration for user setup..."
+IGNITION_CONFIG_TARGET_DIR="/usr/lib/ignition/config.d"
+# The build context (from Containerfile's "FROM scratch AS ctx; COPY build_files /")
+# makes files from build_files/ available under /ctx/ in this script.
+IGNITION_CONFIG_SOURCE_FILE="/ctx/99-user-setup.ign"
+
+if [ -f "${IGNITION_CONFIG_SOURCE_FILE}" ]; then
+mkdir -p "${IGNITION_CONFIG_TARGET_DIR}"
+cp "${IGNITION_CONFIG_SOURCE_FILE}" "${IGNITION_CONFIG_TARGET_DIR}/99-user-setup.ign"
+chmod 644 "${IGNITION_CONFIG_TARGET_DIR}/99-user-setup.ign"
+echo "Successfully embedded '99-user-setup.ign'."
+else
+echo "WARNING: Ignition config file '${IGNITION_CONFIG_SOURCE_FILE}' not found. User setup may be incomplete."
+fi
+
 ### Install packages
 
 # Packages can be installed from any enabled yum repo on the image.

--- a/iso.toml
+++ b/iso.toml
@@ -1,7 +1,7 @@
 [customizations.installer.kickstart]
 contents = """
 %post
-bootc switch --mutate-in-place --transport registry ghcr.io/yourrepo/yourimage:latest
+bootc switch --mutate-in-place --transport registry ghcr.io/ib-bsb-br/incuscore:latest
 %end
 """
 

--- a/iso.toml
+++ b/iso.toml
@@ -1,7 +1,7 @@
 [customizations.installer.kickstart]
 contents = """
 %post
-bootc switch --mutate-in-place --transport registry ghcr.io/ib-bsb-br/incuscore:latest
+bootc switch --mutate-in-place --transport registry ghcr.io/arian-d/incuscore:latest
 %end
 """
 


### PR DESCRIPTION
---
name: Build ISOs

on:
  workflow_dispatch:
    inputs:
      upload-to-s3:
        description: "Upload to S3"
        required: false
        default: false
        type: boolean
      platform:
        required: true
        type: choice
        options:
          - amd64
          - arm64
  pull_request:
    branches:
      - main
    paths:
      - './iso.toml'
      - './.github/workflows/build-iso.yml'
      - './Justfile'
      # Containerfile changes in this repo no longer directly trigger ISO rebuilds
      # unless this workflow is also responsible for testing local Containerfile changes
      # by building a temporary image. Given the new constraint, we assume it's not.

env:
  # Define the exact image to pull
  # This image is expected to be built and pushed by a separate workflow (e.g., build.yml in Arian-D/incuscore)
  PREBUILT_IMAGE_PATH: "ghcr.io/arian-d/incuscore"
  PREBUILT_IMAGE_TAG: "latest" # Or a specific tag like "20250507" for reproducibility

concurrency:
  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
  cancel-in-progress: true

jobs:
  build:
    name: Build ISOs
    runs-on: ${{ inputs.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
    strategy:
      fail-fast: false
    permissions:
      contents: read
      packages: read # <<< CHANGED to read: only needs to pull the public image
      id-token: write # Retained if any future steps might need OIDC

    steps:
      - name: Prepare full image path variable
        id: prep_vars
        run: |
          FULL_IMAGE_TO_PULL="${{ env.PREBUILT_IMAGE_PATH }}:${{ env.PREBUILT_IMAGE_TAG }}"
          echo "FULL_IMAGE_TO_PULL=${FULL_IMAGE_TO_PULL}" >> $GITHUB_ENV
          echo "Image to be used for ISO: ${FULL_IMAGE_TO_PULL}"

      - name: Install dependencies (for arm64 runner)
        if: inputs.platform == 'arm64'
        run: |
          set -x
          sudo apt update -y
          sudo apt install -y podman

      - name: Maximize build space (for amd64 runner)
        if: inputs.platform != 'arm64'
        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e
        with:
          remove-codeql: true

      - name: Checkout repository (contains iso.toml, Justfile etc.)
        uses: actions/checkout@v4

      - name: Log in to GitHub Container Registry (to pull image)
        # While ghcr.io/arian-d/incuscore is public, login can prevent rate limits
        # and is good practice if any private base images were ever involved.
        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

      - name: Pull Pre-built Container Image
        run: |
          echo "Attempting to pull ${{ env.FULL_IMAGE_TO_PULL }}"
          # Workflow will fail here if the image doesn't exist or pull fails.
          docker pull ${{ env.FULL_IMAGE_TO_PULL }}
          echo "Successfully pulled image ${{ env.FULL_IMAGE_TO_PULL }}"

      - name: Setup Just
        uses: extractions/setup-just@v3

      - name: Ensure yum symlink (for tools on runner if needed)
        run: |
          if command -v dnf &> /dev/null && ! command -v yum &> /dev/null; then
            sudo ln -sf /usr/bin/dnf /usr/bin/yum
            echo "Symlinked /usr/bin/dnf to /usr/bin/yum"
          else
            echo "yum command already exists or dnf not found. Skipping symlink."
          fi

      - name: Build ISO using bootc-image-builder
        id: build_iso
        uses: ublue-os/bootc-image-builder-action@main
        with:
          bootc-image-builder-image: ghcr.io/centos-workstation/bootc-image-builder:latest
          use-librepo: true
          config-file: ./iso.toml
          # The 'image' parameter is the source OCI/Docker image to convert
          image: ${{ env.FULL_IMAGE_TO_PULL }}

      - name: Upload ISO and Checksum to Job Artifacts
        if: inputs.upload-to-s3 != true && github.event_name != 'pull_request'
        uses: actions/upload-artifact@v4
        with:
          name: bootable-iso-${{ inputs.platform || 'amd64' }}
          path: ${{ steps.build_iso.outputs.output-directory }}
          if-no-files-found: error
          retention-days: 7
          compression-level: 0
          overwrite: true
